### PR TITLE
TestClient is only use on test

### DIFF
--- a/src/NavigationBundle/Resources/config/services.yaml
+++ b/src/NavigationBundle/Resources/config/services.yaml
@@ -29,8 +29,3 @@ services:
         class: DH\NavigationBundle\NavigationManager
         arguments: ["@dh_navigation.provider_aggregator"]
         public: true
-
-    dh_navigation.test_http_client:
-        class: DH\NavigationBundle\Tests\TestClient
-        shared: false
-        public: true

--- a/tests/NavigationBundle/BaseTest.php
+++ b/tests/NavigationBundle/BaseTest.php
@@ -5,8 +5,10 @@ namespace DH\DoctrineAuditBundle\Tests;
 use DH\NavigationBundle\DependencyInjection\DHNavigationExtension;
 use DH\NavigationBundle\DHNavigationBundle;
 use DH\NavigationBundle\NavigationManager;
+use DH\NavigationBundle\Tests\TestClient;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\Yaml\Yaml;
 
 abstract class BaseTest extends TestCase
@@ -22,6 +24,11 @@ abstract class BaseTest extends TestCase
 
         $bundle = new DHNavigationBundle();
         $bundle->build($container);
+
+        // Test client
+        $definition = new Definition(TestClient::class);
+        $definition->setShared(false);
+        $container->setDefinition('dh_navigation.test_http_client', $definition);
 
         $config = Yaml::parse(file_get_contents(__DIR__.'/Fixtures/dh_navigation.yaml'));
         $config = $this->setupFromEnvVars($config);


### PR DESCRIPTION
This way, the TestClient service is only used for testing.
Otherwise the service is present in classic use and as it is in the "autoload-dev" section, the "lint:container" cann't find the class